### PR TITLE
Minor Updates translations.js

### DIFF
--- a/src/components/translations.js
+++ b/src/components/translations.js
@@ -57,12 +57,12 @@ export default {
     },
     body: {
       title: 'Vente de PNK Kleros',
-      contribute: 'Comment contribuer',
+      contribute: 'Comment Contribuer',
       basicHeading: 'Méthode Simple',
       basic: {
         title: (
           <>
-            Envoyez vos ETH directement à l adresse suivante<sup>*</sup>
+            Envoyez vos ETH directement à l\'adresse suivante<sup>*</sup>
           </>
         ),
         copyContrib: "Copier l'adresse",


### PR DESCRIPTION
Minor updates in the French translation:
I put a capital letter to "contribute" since it was the case on the other translations.
I added the missing apostrophe and escaped it on "Envoyez vos ETH directement à **l'adresse** suivante*"